### PR TITLE
prevent redirect on LOGIN_FAIL at login page

### DIFF
--- a/src/containers/auth/Login.js
+++ b/src/containers/auth/Login.js
@@ -7,7 +7,8 @@ import Loader from 'react-loader-spinner'
 import { Navigate } from 'react-router'
 const Login = ({
   login,
-  loading
+  loading,
+  isAuthenticated
 }) => {
 
   useEffect(() => {
@@ -24,17 +25,14 @@ const Login = ({
     password,
   } = formData;
 
-  const [activated, setActivated] = useState(false);
-
   const onChange = e => setFormData({ ...formData, [e.target.name]: e.target.value });
 
   const onSubmit = e =>{
     e.preventDefault();
     login(email, password);
-    setActivated(true);
   }
 
-  if (activated)
+  if (isAuthenticated)
     return <Navigate to='/' />;
 
   return (
@@ -137,7 +135,8 @@ const Login = ({
   )
 }
 const mapStateToProps = state => ({
-  loading: state.Auth.loading
+  loading: state.Auth.loading,
+  isAuthenticated: state.Auth.isAuthenticated
 })
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
Uses mapStateToProps to prevent redirect with LOGIN_FAIL on Login page and redirect if login is successful only.